### PR TITLE
fix: Use the same RPC timeout for all rpc call

### DIFF
--- a/chains/eth/block_fetcher.go
+++ b/chains/eth/block_fetcher.go
@@ -106,7 +106,7 @@ func (bf *defaultBlockFetcher) getBlock(height int64) (*etypes.Block, error) {
 	if height == -1 { // latest block
 		blockNum = nil
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(bf.blockTime)*2*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), RpcTimeOut)
 	defer cancel()
 
 	return bf.client.BlockByNumber(ctx, blockNum)
@@ -143,7 +143,7 @@ func (bf *defaultBlockFetcher) tryGetBlock() (*etypes.Block, error) {
 }
 
 func (bf *defaultBlockFetcher) getBlockNumber() (uint64, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(bf.blockTime)*2*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), RpcTimeOut)
 	defer cancel()
 
 	return bf.client.BlockNumber(ctx)

--- a/chains/eth/client.go
+++ b/chains/eth/client.go
@@ -23,6 +23,10 @@ import (
 	"golang.org/x/net/html"
 )
 
+var (
+	RpcTimeOut = time.Second * 5
+)
+
 type NoHealthyClientErr struct {
 	chain string
 }
@@ -135,7 +139,7 @@ func (c *defaultEthClient) getRpcsHealthiness(allRpcs []string) ([]string, []*et
 	for _, rpc := range allRpcs {
 		client, err := ethclient.Dial(rpc)
 		if err == nil {
-			ctx, cancel := context.WithTimeout(context.Background(), time.Duration(time.Second*5))
+			ctx, cancel := context.WithTimeout(context.Background(), RpcTimeOut)
 			block, err := client.BlockByNumber(ctx, nil)
 			cancel()
 

--- a/chains/eth/receipt_fetcher.go
+++ b/chains/eth/receipt_fetcher.go
@@ -80,7 +80,7 @@ func (rf *defaultReceiptFetcher) getResponse(request *txReceiptRequest) *txRecei
 		tx := txQueue[0]
 		ok := false
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+		ctx, cancel := context.WithTimeout(context.Background(), RpcTimeOut)
 		receipt, err := rf.client.TransactionReceipt(ctx, tx.Hash())
 		cancel()
 

--- a/chains/eth/watcher.go
+++ b/chains/eth/watcher.go
@@ -6,7 +6,6 @@ import (
 	"math/big"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	etypes "github.com/ethereum/go-ethereum/core/types"
@@ -243,7 +242,7 @@ func (w *Watcher) extractTxs(response *txReceiptResponse) *types.Txs {
 }
 
 func (w *Watcher) getSuggestedGasPrice() (*big.Int, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(w.blockTime)*2*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), RpcTimeOut)
 	defer cancel()
 
 	return w.client.SuggestGasPrice(ctx)
@@ -339,7 +338,7 @@ func (w *Watcher) TrackTx(txHash string) {
 }
 
 func (w *Watcher) getTransactionReceipt(txHash common.Hash) (*etypes.Receipt, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	ctx, cancel := context.WithTimeout(context.Background(), RpcTimeOut)
 	defer cancel()
 	receipt, err := w.client.TransactionReceipt(ctx, txHash)
 


### PR DESCRIPTION
This PR increases timeout for rpc call to 5 seconds to all RPC call (instead of relying on block time)